### PR TITLE
fix(example): resolve search result images in 01_full_app

### DIFF
--- a/example/01_full_app/lib/main.dart
+++ b/example/01_full_app/lib/main.dart
@@ -154,7 +154,8 @@ List<ExampleSearchCandidate> exampleSearchCandidates(
       'path',
     ]);
     final filename = exampleFilename(rawName);
-    if (filename.isEmpty) continue;
+    final title = filename.isEmpty ? _candidateFileName(row) : filename;
+    if (title.isEmpty) continue;
     final stream = exampleFirstText(row, const <String>['stream_name']);
     final timestamp = exampleTimestamp13(
       exampleFirstText(row, const <String>[
@@ -166,9 +167,9 @@ List<ExampleSearchCandidate> exampleSearchCandidates(
     final record = <String, Object?>{
       'mode': 'vid_file',
       'group_name': collectionName.trim(),
-      'modality': 'image',
+      'modality': 'vid_img',
       'stream_name': stream.isEmpty ? streamName.trim() : stream,
-      'filename': filename,
+      'filename': title,
       if (timestamp.isNotEmpty) 'ts_unix_13digits': timestamp,
     };
     candidates.add(
@@ -176,6 +177,33 @@ List<ExampleSearchCandidate> exampleSearchCandidates(
     );
   }
   return candidates;
+}
+
+String _candidateFileName(Map<String, Object?> map) {
+  String? text(String key) {
+    final v = map[key];
+    if (v == null) return null;
+    final s = (v is String ? v : v.toString()).trim();
+    return s.isEmpty ? null : s;
+  }
+
+  // 1. Prefer the explicit title, then reconstruct from item_id.
+  final title = text('title');
+  if (title != null) return title;
+
+  final id = text('item_id');
+  final stream = text('stream');
+  final unix = text('ts_unix');
+  if (id == null || stream == null || unix == null) return '';
+  var middle = id;
+  if (middle.startsWith('$stream-')) {
+    middle = middle.substring(stream.length + 1);
+  }
+  if (middle.endsWith('-$unix')) {
+    middle = middle.substring(0, middle.length - unix.length - 1);
+  }
+  middle = middle.trim();
+  return middle.isEmpty ? id : middle;
 }
 
 int? _exampleInputIndex(Object? value) {

--- a/example/01_full_app/lib/main.dart
+++ b/example/01_full_app/lib/main.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:file_selector/file_selector.dart';
@@ -125,6 +126,7 @@ class ExampleSearchImage {
     required this.stream,
     required this.timestamp,
     required this.score,
+    this.bytes,
   });
 
   final String id;
@@ -134,6 +136,7 @@ class ExampleSearchImage {
   final String stream;
   final String timestamp;
   final String score;
+  final Uint8List? bytes;
 }
 
 List<ExampleSearchCandidate> exampleSearchCandidates(
@@ -212,9 +215,25 @@ int? _exampleInputIndex(Object? value) {
   return null;
 }
 
+Map<String, Uint8List> exampleDecodeImageBytes(ImageGetBulkResponse response) {
+  final decoded = <String, Uint8List>{};
+  for (final raw in response.records) {
+    final url = '${raw['url_pre_signed'] ?? ''}'.trim();
+    final encoded = '${raw['content_base64'] ?? ''}'.trim();
+    if (url.isEmpty || encoded.isEmpty) continue;
+    try {
+      decoded[url] = base64Decode(encoded);
+    } on FormatException {
+      continue;
+    }
+  }
+  return decoded;
+}
+
 List<ExampleSearchImage> exampleSearchImages(
   List<ExampleSearchCandidate> candidates,
   ImageUrlBulkResponse response,
+  Map<String, Uint8List> imageMap,
 ) {
   final resolved = <int, ExampleSearchImage>{};
   for (var rowIndex = 0; rowIndex < response.records.length; rowIndex++) {
@@ -256,6 +275,7 @@ List<ExampleSearchImage> exampleSearchImages(
       stream: stream,
       timestamp: timestamp,
       score: exampleScore(hit),
+      bytes: imageMap[url],
     );
   }
   final indexes = resolved.keys.toList()..sort();
@@ -375,7 +395,9 @@ class ExampleSearchImageCard extends StatelessWidget {
           AspectRatio(
             aspectRatio: 1,
             child: Image(
-              image: imageProviderFactory(image.url),
+              image: image.bytes == null
+                  ? imageProviderFactory(image.url)
+                  : MemoryImage(image.bytes!),
               fit: BoxFit.cover,
               semanticLabel: 'Search result image: ${image.title}',
               loadingBuilder:
@@ -721,7 +743,15 @@ class _VmodalExampleAppState extends State<VmodalExampleApp> {
                 .toList(),
           );
           if (!_currentSearch(generation, query, collection, stream)) return;
-          images = exampleSearchImages(candidates, urls);
+          final urlList = urls.records
+              .where((row) => row['found'] != false)
+              .map((row) => '${row['url_pre_signed'] ?? ''}'.trim())
+              .where((String url) => url.isNotEmpty)
+              .toList();
+          final contents = await client.images.getImageBulkFromUrls(urlList);
+          if (!_currentSearch(generation, query, collection, stream)) return;
+          final imageMap = exampleDecodeImageBytes(contents);
+          images = exampleSearchImages(candidates, urls, imageMap);
         }
         _safeState(() {
           _images = images;

--- a/example/01_full_app/test/widget_test.dart
+++ b/example/01_full_app/test/widget_test.dart
@@ -164,7 +164,7 @@ void main() {
     expect(candidate.record, <String, Object?>{
       'mode': 'vid_file',
       'group_name': 'videos',
-      'modality': 'image',
+      'modality': 'vid_img',
       'stream_name': 'custom',
       'filename': 'clip.mp4',
       'ts_unix_13digits': '1700000000000',
@@ -181,6 +181,7 @@ void main() {
           },
         ],
       }),
+      const <String, Uint8List>{},
     ).single;
     expect(image.title, 'Red bicycle');
     expect(image.filename, 'clip.mp4');
@@ -190,7 +191,7 @@ void main() {
     expect(image.id, isNot(contains(image.url)));
   });
 
-  test('all filename aliases use basename and blank hits are omitted', () {
+  test('filename aliases use basename and blank names fall back to title', () {
     _log('checking every documented filename alias and both path separators');
     const keys = <String>[
       'filename',
@@ -217,7 +218,9 @@ void main() {
         <String, Object?>{'title': 'No file'},
       ],
     });
-    expect(exampleSearchCandidates(blank, 'group', 'stream'), isEmpty);
+    final candidates = exampleSearchCandidates(blank, 'group', 'stream');
+    expect(candidates, hasLength(1));
+    expect(candidates.single.record, containsPair('filename', 'No file'));
   });
 
   test('timestamps normalize to the 13-digit lookup contract', () {
@@ -282,6 +285,7 @@ void main() {
             <String, Object?>{'input_index': 3, 'url_pre_signed': ' '},
           ],
         }),
+        const <String, Uint8List>{},
       );
       expect(images.map((ExampleSearchImage image) => image.title), <String>[
         'Title 0',
@@ -312,6 +316,7 @@ void main() {
           <String, Object?>{'url_pre_signed': 'https://image.test/outside'},
         ],
       }),
+      const <String, Uint8List>{},
     );
     expect(images.map((ExampleSearchImage image) => image.filename), <String>[
       'zero.mp4',


### PR DESCRIPTION
Fixes #16

Two fixes in `example/01_full_app`, reproduced independently on 3dca5b3 with
Flutter 3.47.1 on a physical Android 16 device. Likely also addresses #15.

### 1. Search candidates never match (commit 1)

- `modality: 'image'` -> `'vid_img'`, matching the Android SDK.
- Rows with an empty filename were dropped outright. They now fall back to
  `title`, and then to a name reconstructed from `item_id` by stripping the
  `stream` prefix and `ts_unix` suffix. Rows with none of the three are still
  skipped.

Note: the `item_id` reconstruction reads `stream`, which is a distinct field
from the top-level `stream_name` used elsewhere in the same row.

### 2. Pre-signed URL is not a loadable image URL (commit 2)

`url_pre_signed` is a token for `/image/get_image`, so `NetworkImage` renders
nothing. Result frames are now fetched via `getImageBulkFromUrls`, decoded
once, and rendered with `MemoryImage`. Bytes are keyed by URL rather than by
position, since the response is filtered and its order isn't guaranteed.
`imageProviderFactory` is kept as a fallback so existing widget tests are
unaffected. A malformed base64 entry is skipped rather than failing the whole
search.

### On the test changes

Two existing assertions encoded the buggy behaviour rather than the intended
contract, and both had to change:

- `search hits normalize to exact Android-compatible image records` asserted
  `modality: 'image'` — precisely what diverges from Android.
- `all filename aliases use basename and blank hits are omitted` asserted that
  rows without a filename are dropped, which is the direct cause of
  "0 images from N matches". Renamed to reflect the title fallback.

Flagging this explicitly, since changing tests alongside a fix deserves
scrutiny.

`flutter test` passes (15/15) in `example/01_full_app`.